### PR TITLE
Use the system call ntp_adjtime() instead of the program ntpdc.

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ Usage: (WSPR --help output):
     -p --ppm ppm
       Known PPM correction to 19.2MHz RPi nominal crystal frequency.
     -s --self-calibration
-      Query ntpd before every transmission to obtain the PPM error of the xtal.
+      Call ntp_adjtime() before every transmission to obtain the PPM error of the xtal.
     -r --repeat
       Repeatedly, and in order, transmit on all the specified freqs.
     -x --terminate <n>


### PR DESCRIPTION
I don't ham but NTP, RPi and amateur radio is interesting to me. I hope this patch will be useful to you.
ps. I can't test the patch but it looks right. :)
