### PR TITLE
Removes signal handler for signal 28 (terminal resize signal)

### DIFF
--- a/wspr.cpp
+++ b/wspr.cpp
@@ -44,6 +44,7 @@
 #include <algorithm>
 #include <pthread.h>
 #include <sys/timex.h>
+#include <signal.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1120,6 +1121,11 @@ void setup_peri_base_virt(
 int main(const int argc, char * const argv[]) {
   //catch all signals (like ctrl+c, ctrl+z, ...) to ensure DMA is disabled
   for (int i = 0; i < 64; i++) {
+    // Do not set up a handler for signal 28 (SIGWINCH).  This signal is used
+    // to signify a terminal window resize event and is NOT a reason for the
+    // process to terminate.
+    if (i == SIGWINCH)
+      continue;
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = cleanupAndExit;


### PR DESCRIPTION
The cleanup handler in this application was reponding to any and all process signals.
The intent was for cleanup to run regardless of how the application was terminated
(SIGTERM, SIGKILL, etc.).  This behavior is inappropriate because certain signals, like
28, are simply used to notify the process of system events.  Signal 28 (SIGWINCH) is
used to signal a terminal resize event.

It is likely the console blanking feature on the Pi is also sending this signal, which
would cause a undesired shutdown of the program.