### PR TITLE
Fixed "undefined reference to makedev"

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include "mailbox.h"
 


### PR DESCRIPTION
 Fixed 
```
mailbox.o: In function `mbox_open':
mailbox.c:(.text+0xc54): undefined reference to `makedev'
mailbox.c:(.text+0xcbc): undefined reference to `makedev'
```